### PR TITLE
Final version to submit to Jim, et al, for testing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,38 +4,40 @@
 #include <ESP_FlexyStepper.h>
 #include <elapsedMillis.h>
 
-#define HOME 0
-#define BPM_MULTIPLIER 30  // SWAG at this point
 #define VOLUME_TO_MM_CONVERSION 33.3 // BAS: 33.3 is according to Forrest's spec document
-#define MAX_STROKE_LENGTH_IN_MM 254.0 // BAS: 10 inches - just a guess! Need to change 
-                                      // to the actual distance necessary to get the pistion to the desired 
+#define ACTUAL_LENGTH_OF_SCREW_IN_MM 300 // BAS: this is a guess - make it the actual length!
+#define MAX_STROKE_LENGTH_IN_MM 254.0 // BAS: 10 inches - just a guess! Need to change to the actual distance
+                                      // necessary to get the piston from the "homed" position to the desired 
                                       // starting point for every inhale cycle.
+float home_in_mm = 0.0; // will be set by the homing operation
 
+// knob display min, max, and starting values
+const float VOL_KNOB_MIN_VAL = 1.0;
+const float VOL_KNOB_MAX_VAL = 6.0;
+const uint16_t VOL_KNOB_START_VAL = 3.0;
+const uint16_t BPM_KNOB_MIN_VAL = 10;
+const uint16_t BPM_KNOB_MAX_VAL = 30;
+const uint16_t BPM_KNOB_START_VAL = 20;
+
+// defines the region of the OLED to be updated with knob turns
 int topcornerX = 1;
 int topcornerY = 30;
 int bottomcornerX = 128;
 int bottomcornerY = 64;
 
-/**
- * @brief Updates only the area of the OLED that displays the Volume
- */
-void update_oled(float volume, uint8_t bpm) {
-  Heltec.display->setColor(BLACK);
-  Heltec.display->fillRect(topcornerX, topcornerY, bottomcornerX, bottomcornerY);
-  Heltec.display->setColor(WHITE);
-  String rpm_vol_str = String(bpm) + "       " + String(volume, 1);
-  Heltec.display->drawString(10, 26, rpm_vol_str);
-  Heltec.display->display();
-  Serial.println("BPM: " + String(bpm) + "   Volume: " + String(volume, 1));
-}
-
+// this is LED_BUILTIN. It's currently used in the isr's to give an immediate indication that the isr
+// has been called, since the OLED won't update until the end of the next cycle.
+// Can be removed once everything is working, to make the isr's even smaller
 static bool led = LOW;
-static bool bpm_knob_interrupt_fired = false;
-static bool home_btn_interrupt_fired = false;
-static bool volume_knob_interrupt_fired = false;
-static bool pause_btn_interrupt_fired = false;
-static bool limit_switch_interrupt_fired = false;
 
+static bool bpm_knob_interrupt_fired = false;
+static bool volume_knob_interrupt_fired = false;
+
+// not yet implented:
+static bool home_btn_interrupt_fired = false;
+static bool pause_btn_interrupt_fired = false;
+
+// define all pins to match Forrest's schematic
 const uint8_t pause_btn_pin = 38; // the pushbutton on the bpm encoder
 const uint8_t home_btn_pin = 35; // the pushbutton on the volume encoder
 const uint8_t co2_btn_pin = 25; // the pushbutton on the co2 encoder
@@ -50,7 +52,7 @@ const uint8_t motor_direction_pin = 14;
 const uint8_t limit_switch_data_pin = 12; // BAS: make sure this is the DATA line of the limit switch
 const uint8_t limit_switch_led_pin = 13;
 
-// define all the ISR's and ISR callbacks
+// define the knob turn callbacks
 static IRAM_ATTR void bpm_knob_cb(void *arg) {
   digitalWrite(LED_BUILTIN, led);
   led = !led;
@@ -63,35 +65,46 @@ static IRAM_ATTR void volume_knob_cb(void *arg) {
   volume_knob_interrupt_fired = true;
 }
 
-// BAS: check this interrupt inside the two while() loops, to execute an emergency stop?
-void limit_switch_isr() {
-  digitalWrite(LED_BUILTIN, led);
-  led = !led;
-  limit_switch_interrupt_fired = true;
-}
-
+// instantiate the encoders with their associated callback functions
 ESP32Encoder bpm_knob(true, bpm_knob_cb);
 ESP32Encoder volume_knob(true, volume_knob_cb);
 
 /**
+ * @brief Updates only the area of the OLED that displays the BPM and Volume values
+ */
+void update_oled(float volume, uint8_t bpm) {
+  Heltec.display->setColor(BLACK);
+  Heltec.display->fillRect(topcornerX, topcornerY, bottomcornerX, bottomcornerY);
+  Heltec.display->setColor(WHITE);
+  String rpm_vol_str = String(bpm) + "       " + String(volume, 1);
+  Heltec.display->drawString(10, 26, rpm_vol_str);
+  Heltec.display->display();
+  // BAS: for testing only - remove before final, to make the ISRs run faster
+  Serial.println("BPM: " + String(bpm) + "   Volume: " + String(volume, 1));
+}
+
+/**
  * @brief Read the current value of the Volume knob, convert it to a float,
+ * make sure it's within the define minimum and maximum values for this knob,
  * and return 1/10 of the value, so the display can be to 1 decimal. Always
  * use this function to read the knob, so that all volume values will be
- * consistent! 
+ * consistent!
+ * 
+ * Note - since the encoders deal in ints, getCount() and setCount() do too.
+ * So getCount() values are divided by 10 to convert, for example, 30 to 3.0,
+ * and setCount() values are multiplied by 10, so 3.0 becomes 30.
  */
-float get_volume_as_float() { // BAS: make all the values in this function come from #define statements
-  float count = (float)volume_knob.getCount() / 10;
-  if (count > 6.0)
-  {
-    count = 1.0;
-    volume_knob.setCount(10);
+float get_volume_as_float() {
+  float count_as_float = (float)(volume_knob.getCount() / 10);
+  if (count_as_float > VOL_KNOB_MAX_VAL) {
+    count_as_float = VOL_KNOB_MIN_VAL;
+    volume_knob.setCount((uint16_t)(VOL_KNOB_MIN_VAL * 10));
   }
-  else if (count < 1.0)
-  {
-    count = 6.0;
-    volume_knob.setCount(60);
+  else if (count_as_float < VOL_KNOB_MIN_VAL) {
+    count_as_float = VOL_KNOB_MAX_VAL;
+    volume_knob.setCount((uint16_t)(VOL_KNOB_MAX_VAL * 10));
   }
-  return count;
+  return count_as_float;
 }
 
 /**
@@ -99,32 +112,41 @@ float get_volume_as_float() { // BAS: make all the values in this function come 
  * use this function to read the knob, so that all BPM values will be
  * consistent! 
  */
-uint8_t get_bpm_as_int() { // BAS: make all the values in this function come from #define statements
-  uint8_t count = bpm_knob.getCount();
-  if (count > 40)
-  {
-    count = 20;
-    bpm_knob.setCount(20);
+uint8_t get_bpm_as_int() {
+  uint8_t count_as_int = bpm_knob.getCount();
+  if (count_as_int > BPM_KNOB_MAX_VAL) {
+    count_as_int = BPM_KNOB_MIN_VAL;
+    bpm_knob.setCount(BPM_KNOB_MIN_VAL);
   }
-  else if (count < 20)
-  {
-    count = 40;
-    bpm_knob.setCount(40);
+  else if (count_as_int < BPM_KNOB_MIN_VAL) {
+    count_as_int = BPM_KNOB_MAX_VAL;
+    bpm_knob.setCount(BPM_KNOB_MAX_VAL);
   }
-  return count;
+  return count_as_int;
 }
 
+// Instantiate the stepper
 ESP_FlexyStepper stepper;
-//elapsedMillis bpm_timer = 0;
 
-float motorStepsPerMillimeter = 25; // BAS: verified
-float distanceToMoveInMillimeters = 76;  // just a starting value - is really controlled by volume knob
-float speedInMillimetersPerSecond = 200; // just a starting value - controlled by bpm knob
-float accelerationInMillimetersPerSecondPerSecond = 100; // just a starting value - controlled by bpm knob
-float decelerationInMillimetersPerSecondPerSecond = 100; // just a starting value - controlled by bpm knob
 
-float target_position_in_mm = VOLUME_TO_MM_CONVERSION; // sets the initial target, until the volume knob is turned
-uint8_t bpm_desired = 1 * BPM_MULTIPLIER; // sets the initial BPM, until the BPM knob is turned
+/**
+ * @brief calculate and set the speed, acceleration, and deceleration factors of 
+ * the stepper based on the given volume and bpm, based on Forrest's formula.
+ * 
+ * @param volume - typically, get_volume_as_float()
+ * @param bpm - typically, get_bpm_as_int()
+ */
+void set_speed_factors(float volume, uint16_t bpm) {
+  float desired_speed = volume * VOLUME_TO_MM_CONVERSION * 2.0 * bpm / 60; // Forrest's formula
+  stepper.setSpeedInMillimetersPerSecond(desired_speed);
+  stepper.setAccelerationInMillimetersPerSecondPerSecond(desired_speed * desired_speed);
+  stepper.setDecelerationInMillimetersPerSecondPerSecond(desired_speed * desired_speed);
+}
+
+float motorStepsPerMillimeter = 25; // BAS: verified on Jim's test jig
+
+float target_position_in_mm = VOL_KNOB_START_VAL * VOLUME_TO_MM_CONVERSION; // sets the initial target, until the volume knob is turned
+
 
 void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
@@ -135,21 +157,18 @@ void setup() {
   ESP32Encoder::useInternalWeakPullResistors = UP;
 
   bpm_knob.attachSingleEdge(bpm_DT_pin, bpm_CLK_pin);
-  // following line, along with a 0.1uF cap to GND, is for debouncing
   bpm_knob.setFilter(1023);
-  bpm_knob.setCount(25); // set the initially-displayed BPM
+  bpm_knob.setCount(BPM_KNOB_START_VAL); // set the initially-displayed BPM
 
   volume_knob.attachSingleEdge(volume_DT_pin, volume_CLK_pin);
   volume_knob.setFilter(1023);
-  volume_knob.setCount(30); // set the initially-displayed volume (30 is displayed as 3.0)
+  volume_knob.setCount(VOL_KNOB_START_VAL); // set the initially-displayed Volume
 
   //attachInterrupt(limit_switch_data_pin, LOW);
 
   stepper.connectToPins(motor_pulse_pin, motor_direction_pin);
   stepper.setStepsPerMillimeter(motorStepsPerMillimeter);
-  stepper.setSpeedInMillimetersPerSecond(speedInMillimetersPerSecond);
-  stepper.setAccelerationInMillimetersPerSecondPerSecond(accelerationInMillimetersPerSecondPerSecond);
-  stepper.setDecelerationInMillimetersPerSecondPerSecond(decelerationInMillimetersPerSecondPerSecond);
+  set_speed_factors(get_volume_as_float(), get_bpm_as_int());
 
   Heltec.begin(true, false, true);
   Heltec.display->clear();
@@ -161,52 +180,66 @@ void setup() {
   Heltec.display->setFont(ArialMT_Plain_24);
   update_oled(get_volume_as_float(), get_bpm_as_int());
 
-  /* stepper.moveToHomeInSteps(char_directionToHome, f_speedInStepsPerSecond, long_maxDistanceToMoveInSteps,
-                            int_homeLimitSwitchPin);
-                            */
+  /* 
+  These are the parameters to moveToHomeInMillimeters:
+  stepper.moveToHomeInMillimeters(signed char directionTowardHome,
+                                  float speedInMillimetersPerSecond, 
+                                  long maxDistanceToMoveInMillimeters,
+                                  int homeLimitSwitchPin)      */
   Serial.println("Starting homing operation");
-  bool homing_successful = stepper.moveToHomeInMillimeters(-1, 10.0, (100), limit_switch_data_pin);
+  // BAS: if the piston moves the wrong direction at startup, change the first parameter below to -1
+  bool homing_successful = stepper.moveToHomeInMillimeters(1, 15, ACTUAL_LENGTH_OF_SCREW_IN_MM, limit_switch_data_pin);
   Serial.println("Homing successful? " + String(homing_successful));
+
   // at this point, the piston should be just past the point where the limit switch has gone HIGH again.
   // for safety, move the piston another inch or so away from the limit switch
-  stepper.setTargetPositionRelativeInMillimeters(25.4); // BAS: this might need to be NEGATIVE
+  stepper.setTargetPositionRelativeInMillimeters(25.4); // BAS: if piston moves towards limit switch, make this NEGATIVE
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
     stepper.processMovement();
   }
+  Serial.println("Should be 1 inch past the 'homed' position");
 
   // the piston is now at a position that's the closest it should ever get to the limit switch again,
-  // so now move it to the desired position for the start of each inhale stroke - XX mm farther
-  // NOTE: there's no real reason to do this move, and the previous move, separately. I did it that
+  // so now move it to the desired position for the start of each inhale stroke - MAX_STROKE_LENGTH_IN_MM farther.
+
+  // NOTE: there's no real reason to do this move, and the previous move, separately. I did it that way
   // for now just to illustrate what's happening
   stepper.setTargetPositionRelativeInMillimeters(MAX_STROKE_LENGTH_IN_MM); // BAS: this might need to be NEGATIVE
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
     stepper.processMovement();
   }
-  // now we should be at Top Dead Center (TDC) - the point where every inhale stroke begins, and the point where every
-  // exhale stroke returns to.
+  Serial.println("Should now be at the starting point for every inhale stroke");
+
+  // now we should be at the point where every inhale stroke begins, and the point where every
+  // exhale stroke returns to. Save it, to be used by the exhale stroke.
+  home_in_mm = stepper.getCurrentPositionInMillimeters();
 
   // read the current value of the volume encoder and set it as the target position for the first inhale stroke
   stepper.setTargetPositionInMillimeters(get_volume_as_float() * VOLUME_TO_MM_CONVERSION);
+  update_oled(get_volume_as_float(), get_bpm_as_int());
+  set_speed_factors(get_volume_as_float(), get_bpm_as_int());
+  
 } // setup;
 
 void loop() {  
+  
   if (volume_knob_interrupt_fired) {
-
-    update_oled(get_volume_as_float(), get_bpm_as_int());
-    target_position_in_mm = get_volume_as_float() * VOLUME_TO_MM_CONVERSION;
+    float current_volume = get_volume_as_float();
+    uint16_t current_bpm = get_bpm_as_int();
+    update_oled(current_volume, current_bpm);
+    set_speed_factors(current_volume, current_bpm);
+    target_position_in_mm = current_volume * VOLUME_TO_MM_CONVERSION;
     stepper.setTargetPositionInMillimeters(target_position_in_mm);
     volume_knob_interrupt_fired = false;
   }
 
   if (bpm_knob_interrupt_fired) {
-    update_oled(get_volume_as_float(), get_bpm_as_int());
-    bpm_desired = get_bpm_as_int(); 
-    float desired_piston_speed = abs(target_position_in_mm) * 2.0 * bpm_desired  / 60;
-    stepper.setSpeedInMillimetersPerSecond(desired_piston_speed);
-    stepper.setAccelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
-    stepper.setDecelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
+    float current_volume = get_volume_as_float();
+    uint16_t current_bpm = get_bpm_as_int();
+    update_oled(current_volume, current_bpm);
+    set_speed_factors(current_volume, current_bpm);
     bpm_knob_interrupt_fired = false;
   }
 
@@ -215,56 +248,17 @@ void loop() {
   // begine the inhale stroke  
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
-    //bpm_timer = 0;
     stepper.processMovement();
   }
-  //delay(1500); // for testing when not connected to the stepper
-  // save the value of bpm_timer immediately on exiting the while()
-  //uint32_t while_loop_time = bpm_timer;
-  // calculate BPM from bpm_timer: ms_in_a_half_minute / while_loop_ms
-  //float calculated_bpm = 30000.0 / while_loop_time;
-  //Serial.println("inhale while() bpm_timer and calculated BPM: " + String(while_loop_time) + " / " + String(calculated_bpm, 1));
- 
-  // now reverse it for the exhale stroke
-  // check the interrupts between the strokes for better updating of the OLED
-  /* BAS: remove for now - Forrest says he doesn't want any changes until getting back to TDC
-  if (volume_knob_interrupt_fired) {
-
-    update_oled(get_volume_as_float(), get_bpm_as_int());
-    target_position_in_mm = get_volume_as_float() * VOLUME_TO_MM_CONVERSION;
-    // do NOT setTargetPosition at this point - on the exhale stroke, targetPosition is always HOME (eventually TDC)
-    volume_knob_interrupt_fired = false;
-  }
-
-  if (bpm_knob_interrupt_fired) {
-    update_oled(get_volume_as_float(), get_bpm_as_int());
-    bpm_desired = get_bpm_as_int(); float desired_piston_speed = abs(target_position_in_mm) * 2.0 * bpm_desired  / 60;
-    stepper.setSpeedInMillimetersPerSecond(desired_piston_speed);
-    stepper.setAccelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
-    stepper.setDecelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
-    bpm_knob_interrupt_fired = false;
-  }
-  */
-
+  
+  // now begin the exhale stroke
   delay(200);
-  // BAS: be careful here - if the volume interrupt fired between strokes, target_position_in_mm will be a positive
-  // number at this point because it came from the knob. When we start playing with homing, we may flip directionToHome,
-  // so target_position_in_mm might need to be a negative number at this point, so we'd have to make it negative
-  // inside if (volume_knob_interrupt_fired) {}, so when the next line executes, it would become positive.
-  // target_position_in_mm *= -1.0;
-  stepper.setTargetPositionInMillimeters(HOME);
+  stepper.setTargetPositionInMillimeters(home_in_mm);
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
-    //bpm_timer = 0;
     stepper.processMovement();
   }
   // now the piston is back at the start of a new inhale cycle
-  //delay(1234); // for testing when not connected to the stepper
-  //while_loop_time = bpm_timer;
-  //calculated_bpm = 60000.0 / (while_loop_time * 2.0); // BAS: does ths round the way I want?
-  //Serial.println("exhale while_loop_time and calculated BPM: " + String(while_loop_time) + " / " + String(calculated_bpm, 1));
-
-  //delay(100);
-  stepper.setTargetPositionInMillimeters(target_position_in_mm);
+    stepper.setTargetPositionInMillimeters(target_position_in_mm);
   
 } // end loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,9 @@
 #define HOME 0
 #define BPM_MULTIPLIER 30  // SWAG at this point
 #define VOLUME_TO_MM_CONVERSION 33.3 // BAS: 33.3 is according to Forrest's spec document
+#define MAX_STROKE_LENGTH_IN_MM 254.0 // BAS: 10 inches - just a guess! Need to change 
+                                      // to the actual distance necessary to get the pistion to the desired 
+                                      // starting point for every inhale cycle.
 
 int topcornerX = 1;
 int topcornerY = 30;
@@ -112,7 +115,7 @@ uint8_t get_bpm_as_int() { // BAS: make all the values in this function come fro
 }
 
 ESP_FlexyStepper stepper;
-elapsedMillis bpm_timer = 0;
+//elapsedMillis bpm_timer = 0;
 
 float motorStepsPerMillimeter = 25; // BAS: verified
 float distanceToMoveInMillimeters = 76;  // just a starting value - is really controlled by volume knob
@@ -158,24 +161,34 @@ void setup() {
   Heltec.display->setFont(ArialMT_Plain_24);
   update_oled(get_volume_as_float(), get_bpm_as_int());
 
-  // Not working yet
   /* stepper.moveToHomeInSteps(char_directionToHome, f_speedInStepsPerSecond, long_maxDistanceToMoveInSteps,
                             int_homeLimitSwitchPin);
                             */
-  /*
   Serial.println("Starting homing operation");
-  if (!stepper.moveToHomeInSteps(-1, 20.0, (200.0 * 10.0), limit_switch_data_pin)) {
-    for (int x = 0; x < 10; x++) {
-      digitalWrite(LED_BUILTIN, led);
-      led = !led;
-      delay(100);
-    }
+  bool homing_successful = stepper.moveToHomeInMillimeters(-1, 10.0, (100), limit_switch_data_pin);
+  Serial.println("Homing successful? " + String(homing_successful));
+  // at this point, the piston should be just past the point where the limit switch has gone HIGH again.
+  // for safety, move the piston another inch or so away from the limit switch
+  stepper.setTargetPositionRelativeInMillimeters(25.4); // BAS: this might need to be NEGATIVE
+  while (!stepper.motionComplete()) {
+    // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
+    stepper.processMovement();
   }
-  */
 
-  // BAS: Need code here to "home" the piston
-  stepper.setCurrentPositionInMillimeters(HOME);
-  stepper.setTargetPositionInMillimeters(get_volume_as_float() * 25.0);
+  // the piston is now at a position that's the closest it should ever get to the limit switch again,
+  // so now move it to the desired position for the start of each inhale stroke - XX mm farther
+  // NOTE: there's no real reason to do this move, and the previous move, separately. I did it that
+  // for now just to illustrate what's happening
+  stepper.setTargetPositionRelativeInMillimeters(MAX_STROKE_LENGTH_IN_MM); // BAS: this might need to be NEGATIVE
+  while (!stepper.motionComplete()) {
+    // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
+    stepper.processMovement();
+  }
+  // now we should be at Top Dead Center (TDC) - the point where every inhale stroke begins, and the point where every
+  // exhale stroke returns to.
+
+  // read the current value of the volume encoder and set it as the target position for the first inhale stroke
+  stepper.setTargetPositionInMillimeters(get_volume_as_float() * VOLUME_TO_MM_CONVERSION);
 } // setup;
 
 void loop() {  
@@ -189,7 +202,8 @@ void loop() {
 
   if (bpm_knob_interrupt_fired) {
     update_oled(get_volume_as_float(), get_bpm_as_int());
-    bpm_desired = get_bpm_as_int(); float desired_piston_speed = abs(target_position_in_mm) * 2.0 * bpm_desired  / 60;
+    bpm_desired = get_bpm_as_int(); 
+    float desired_piston_speed = abs(target_position_in_mm) * 2.0 * bpm_desired  / 60;
     stepper.setSpeedInMillimetersPerSecond(desired_piston_speed);
     stepper.setAccelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
     stepper.setDecelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
@@ -201,18 +215,19 @@ void loop() {
   // begine the inhale stroke  
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
-    bpm_timer = 0;
+    //bpm_timer = 0;
     stepper.processMovement();
   }
-  delay(1500); // for testing when not connected to the stepper
+  //delay(1500); // for testing when not connected to the stepper
   // save the value of bpm_timer immediately on exiting the while()
-  uint32_t while_loop_time = bpm_timer;
+  //uint32_t while_loop_time = bpm_timer;
   // calculate BPM from bpm_timer: ms_in_a_half_minute / while_loop_ms
-  float calculated_bpm = 30000.0 / while_loop_time;
-  Serial.println("inhale while() bpm_timer and calculated BPM: " + String(while_loop_time) + " / " + String(calculated_bpm, 1));
+  //float calculated_bpm = 30000.0 / while_loop_time;
+  //Serial.println("inhale while() bpm_timer and calculated BPM: " + String(while_loop_time) + " / " + String(calculated_bpm, 1));
  
   // now reverse it for the exhale stroke
   // check the interrupts between the strokes for better updating of the OLED
+  /* BAS: remove for now - Forrest says he doesn't want any changes until getting back to TDC
   if (volume_knob_interrupt_fired) {
 
     update_oled(get_volume_as_float(), get_bpm_as_int());
@@ -229,27 +244,27 @@ void loop() {
     stepper.setDecelerationInMillimetersPerSecondPerSecond(desired_piston_speed * desired_piston_speed);
     bpm_knob_interrupt_fired = false;
   }
+  */
 
   delay(200);
   // BAS: be careful here - if the volume interrupt fired between strokes, target_position_in_mm will be a positive
   // number at this point because it came from the knob. When we start playing with homing, we may flip directionToHome,
   // so target_position_in_mm might need to be a negative number at this point, so we'd have to make it negative
   // inside if (volume_knob_interrupt_fired) {}, so when the next line executes, it would become positive.
-  target_position_in_mm *= -1.0;
+  // target_position_in_mm *= -1.0;
   stepper.setTargetPositionInMillimeters(HOME);
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
-    bpm_timer = 0;
+    //bpm_timer = 0;
     stepper.processMovement();
   }
-  delay(1234); // for testing when not connected to the stepper
-  while_loop_time = bpm_timer;
-  calculated_bpm = 60000.0 / (while_loop_time * 2.0); // BAS: does ths round the way I want?
-  Serial.println("exhale while_loop_time and calculated BPM: " + String(while_loop_time) + " / " + String(calculated_bpm, 1));
+  // now the piston is back at the start of a new inhale cycle
+  //delay(1234); // for testing when not connected to the stepper
+  //while_loop_time = bpm_timer;
+  //calculated_bpm = 60000.0 / (while_loop_time * 2.0); // BAS: does ths round the way I want?
+  //Serial.println("exhale while_loop_time and calculated BPM: " + String(while_loop_time) + " / " + String(calculated_bpm, 1));
 
   //delay(100);
-  // change directions for the next inhale
-  target_position_in_mm *= -1.0;
   stepper.setTargetPositionInMillimeters(target_position_in_mm);
   
 } // end loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include <elapsedMillis.h>
 
 #define VOLUME_TO_MM_CONVERSION 33.3 // BAS: 33.3 is according to Forrest's spec document
-#define ACTUAL_LENGTH_OF_SCREW_IN_MM 300 // BAS: this is a guess - make it the actual length!
+#define ACTUAL_LENGTH_OF_SCREW_IN_MM 300.0 // BAS: this is a guess - make it the actual length!
 #define MAX_STROKE_LENGTH_IN_MM 254.0 // BAS: 10 inches - just a guess! Need to change to the actual distance
                                       // necessary to get the piston from the "homed" position to the desired 
                                       // starting point for every inhale cycle.
@@ -14,7 +14,7 @@ float home_in_mm = 0.0; // will be set by the homing operation
 // knob display min, max, and starting values
 const float VOL_KNOB_MIN_VAL = 1.0;
 const float VOL_KNOB_MAX_VAL = 6.0;
-const uint16_t VOL_KNOB_START_VAL = 3.0;
+const uint16_t VOL_KNOB_START_VAL = 3;
 const uint16_t BPM_KNOB_MIN_VAL = 10;
 const uint16_t BPM_KNOB_MAX_VAL = 30;
 const uint16_t BPM_KNOB_START_VAL = 20;
@@ -162,7 +162,7 @@ void setup() {
 
   volume_knob.attachSingleEdge(volume_DT_pin, volume_CLK_pin);
   volume_knob.setFilter(1023);
-  volume_knob.setCount(VOL_KNOB_START_VAL); // set the initially-displayed Volume
+  volume_knob.setCount(VOL_KNOB_START_VAL * 10); // set the initially-displayed Volume (3 * 10; will be divide by 10 for display)
 
   //attachInterrupt(limit_switch_data_pin, LOW);
 
@@ -220,7 +220,7 @@ void setup() {
   stepper.setTargetPositionInMillimeters(get_volume_as_float() * VOLUME_TO_MM_CONVERSION);
   update_oled(get_volume_as_float(), get_bpm_as_int());
   set_speed_factors(get_volume_as_float(), get_bpm_as_int());
-  
+
 } // setup;
 
 void loop() {  

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include <ESP_FlexyStepper.h>
 #include <elapsedMillis.h>
 
-#define VOLUME_TO_MM_CONVERSION 33.3 // BAS: 33.3 is according to Forrest's spec document
+#define VOLUME_TO_MM_CONVERSION 33.3 // 33.3 is according to Forrest's spec document
 #define ACTUAL_LENGTH_OF_SCREW_IN_MM 300.0 // BAS: this is a guess - make it the actual length!
 #define MAX_STROKE_LENGTH_IN_MM 254.0 // BAS: 10 inches - just a guess! Need to change to the actual distance
                                       // necessary to get the piston from the "homed" position to the desired 
@@ -143,7 +143,7 @@ void set_speed_factors(float volume, uint16_t bpm) {
   stepper.setDecelerationInMillimetersPerSecondPerSecond(desired_speed * desired_speed);
 }
 
-float motorStepsPerMillimeter = 25; // BAS: verified on Jim's test jig
+float motorStepsPerMillimeter = 25; // verified on Jim's test jig
 
 float target_position_in_mm = VOL_KNOB_START_VAL * VOLUME_TO_MM_CONVERSION; // sets the initial target, until the volume knob is turned
 
@@ -205,7 +205,7 @@ void setup() {
 
   // NOTE: there's no real reason to do this move, and the previous move, separately. I did it that way
   // for now just to illustrate what's happening
-  stepper.setTargetPositionRelativeInMillimeters(MAX_STROKE_LENGTH_IN_MM); // BAS: this might need to be NEGATIVE
+  stepper.setTargetPositionRelativeInMillimeters(MAX_STROKE_LENGTH_IN_MM); // BAS: if piston moves towards limit switch, make this NEGATIVE
   while (!stepper.motionComplete()) {
     // Note: Any code added to this loop must execute in no more than 0.05 milliseconds.
     stepper.processMovement();


### PR DESCRIPTION
- checks for, and implements, Volume and BPM changes only at the beginning of each inhale stroke.
- all speed factors (speed, accel, decel) are set by Forrest's formula, based on the desired volume (stroke length) and bpm.
- added const definitions of the starting, maximum, and minimum knob values
- implements the homing function from the FlexyStepper library
- doesn't do anything with the CO2 encoder or swtich - that'll be in the next version, if this version works
- Any comment with "BAS" needs to be considered before building and running this version