### PR TITLE
Replace emergencyStop() with setTargetPositionToStop()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ enum State_t {
 bool tvl_btn_interrupt_fired = false;
 bool rmv_btn_interrupt_fired = false;
 Btn_Action_t pause_btn_action = RESUME; // PAUSE or RESUME - start w/ RESUME (at end of HOMING)
-bool emx_stop_in_effect = false; // set to true when emergencyStop() is called
+bool emx_stop_in_effect = false; // set to true when emergencyStop is called
 bool co2_enabled = false;
 Btn_Action_t co2_btn_action = ENABLE; // ENABLE or DISABLE or NO_ACTION (during calibration)
 elapsedMillis co2_timer = 0.00;
@@ -391,9 +391,9 @@ void set_speed_factors(float volume, uint16_t bpm) {
 }
 
 /**
- * @brief Callback for releaseEmergencyStop(). Gets the piston to inhale_start (0.0),
+ * @brief Callback for releaseEmergencyStop. Gets the piston to inhale_start (0.0),
  * then sets state to INHALE_NEXT, so that no matter what stroke we were in when
- * emergencyStop() was called (INHALE or EXHALE), it will always go to INHALE next.
+ * emergencyStop was called (INHALE or EXHALE), it will always go to INHALE next.
  */
 
 void emx_release_callback()
@@ -469,7 +469,7 @@ void setup() {
   stepper.registerEmergencyStopReleasedCallback(emx_release_callback);
   delay(500);
   int16_t max_stroke_from_memory = read_int_from_eeprom(0);
-  Serial.println("value retrieved from EEPROM = " + String(max_stroke_from_memory)); //BAS: remove this after testing 
+  Serial.println("value retrieved from EEPROM = " + String(max_stroke_from_memory));
   if (digitalRead(co2_btn_pin) == HIGH && max_stroke_from_memory >= HUGE_CALIB_MOVE_IN_MM) { // normal startup w/ a valid value from EEPROM
     state = HOMING;
     MAX_STROKE_LENGTH_IN_MM = max_stroke_from_memory;
@@ -566,7 +566,7 @@ void loop() {
   } // case IDLE
 
   case INHALE_NEXT: {
-    Serial.println("Case INHALE_NEXT"); // for breaking out of an emergencyStop()
+    Serial.println("Case INHALE_NEXT"); // for breaking out of an emergencyStop
     state = INHALE; // BAS: try setting state to IDLE at this point - see if the ensuing stalling stops happening
     break;
   } // case INHALE_NEXT
@@ -591,15 +591,15 @@ void loop() {
         if (pause_btn_action == PAUSE) {
           // co2 valve was already closed, in the isr for this button
           pause_btn_action = RESUME; // set for the next button press
-          stepper.emergencyStop(true); // "true" means "wait for a call to releaseEmergencyStop()" // BAS: try setTargetPositionToStop() here
-          Serial.println("INHALE: pause_btn emergencyStop()");
+          stepper.emergencyStop(true); // "true" means "wait for a call to releaseEmergencyStop" // BAS: try setTargetPositionToStop() here
+          Serial.println("INHALE: pause_btn emergencyStop");
           rmv_btn_interrupt_fired = false;
           emx_stop_in_effect = true;
         }
         else { // pause button press means RESUME
           pause_btn_action = PAUSE; // set for the next button press
           stepper.releaseEmergencyStop(); // BAS: if you use setTargetPositionToStop() above, need to do something different here
-          Serial.println("INHALE: pause_btn releaseEmergencyStop()");
+          Serial.println("INHALE: pause_btn releaseEmergencyStop");
           rmv_btn_interrupt_fired = false;
           emx_stop_in_effect = false;
         }
@@ -607,8 +607,8 @@ void loop() {
       }
       if (tvl_btn_interrupt_fired) {
          // co2 valve has already been closed, in the isr for this button
-         stepper.emergencyStop(false); // "false" = "don't wait for a call to releaseEmergencyStop()" BAS: try setTargetPositionToStop() here
-         Serial.println("INHALE: home_btn emergencyStop()");
+         stepper.emergencyStop(false); // "false" = "don't wait for a call to releaseEmergencyStop" BAS: try setTargetPositionToStop() here
+         Serial.println("INHALE: home_btn emergencyStop");
          state = HOMING;
          tvl_btn_interrupt_fired = false;
          break; // break out of the while(), but not out of the INHALE case
@@ -637,15 +637,15 @@ void loop() {
         if (pause_btn_action == PAUSE) {
           // co2 valve was already closed, in the isr for this button
           pause_btn_action = RESUME; // set for the next button press
-          stepper.emergencyStop(true); // "true" = "wait for a call to releaseEmergencyStop()" // BAS: try setTargetPositionToStop() here
-          Serial.println("EXHALE: pause_btn emergencyStop()");
+          stepper.emergencyStop(true); // "true" = "wait for a call to releaseEmergencyStop" // BAS: try setTargetPositionToStop() here
+          Serial.println("EXHALE: pause_btn emergencyStop");
           rmv_btn_interrupt_fired = false;
           emx_stop_in_effect = true;
         }
         else { // pause button press means "resume"
           pause_btn_action = PAUSE; // set for the next button press
           stepper.releaseEmergencyStop(); // BAS: if you use setTargetPositionToStop above, do something different here
-          Serial.println("EXHALE: pause_btn releaseEmergencyStop()");
+          Serial.println("EXHALE: pause_btn releaseEmergencyStop");
           emx_stop_in_effect = false;
         }
         btn_state_changed = true;
@@ -655,8 +655,8 @@ void loop() {
          // co2 valve has already been closed, in the isr for this button
          state = HOMING;
          tvl_btn_interrupt_fired = false;
-         stepper.emergencyStop(false); // "false" means "don't wait for a call to stepper.releaseEmergencyStop()"
-         Serial.println("EXHALE: home_btn emergencyStop()");
+         stepper.emergencyStop(false); // "false" means "don't wait for a call to stepper.releaseEmergencyStop"
+         Serial.println("EXHALE: home_btn emergencyStop");
          break; // break out of the while()
       }
       get_encoder_values();
@@ -725,7 +725,7 @@ void loop() {
     //stepper.setCurrentPositionInMillimeters(0.0);
     tvl_knob.setCount(TVL_KNOB_START_VAL * 10);
     state = HOMING;
-    Serial.println("Value written to EEPROM: " + String(read_int_from_eeprom(0))); // BAS: remove this when done testing
+    Serial.println("Value written to EEPROM: " + String(read_int_from_eeprom(0)));
     break;
   } // end CALIBRATE
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -400,7 +400,9 @@ void release_a_stop()
 {
   //set_speed_factors(current_volume, current_bpm); BAS: not necessary - speed factors didn't change
   stepper.setTargetPositionInMillimeters(inhale_start);
-  while (!stepper.motionComplete());
+  while (!stepper.motionComplete()) {
+    // do nothing
+  }
   state = INHALE_NEXT;
 }
 
@@ -685,7 +687,9 @@ void loop() {
       if (position != last) {
         Serial.println("position count " + String(position));
         stepper.setTargetPositionInMillimeters(position);
-        while (!stepper.motionComplete());
+        while (!stepper.motionComplete()) {
+          // do nothing
+        }
         last = position;
       }
     }
@@ -696,7 +700,9 @@ void loop() {
     stepper.setAccelerationInMillimetersPerSecondPerSecond(75);
     stepper.setDecelerationInMillimetersPerSecondPerSecond(75);
     stepper.setTargetPositionInMillimeters(HUGE_CALIB_MOVE_IN_MM); // move a lot closer to the inhale beginning point
-    while (!stepper.motionComplete());
+    while (!stepper.motionComplete()) {
+      // do nothing
+    }
     stepper.setSpeedInMillimetersPerSecond(25);
     stepper.setAccelerationInMillimetersPerSecondPerSecond(25);
     stepper.setDecelerationInMillimetersPerSecondPerSecond(25);
@@ -710,7 +716,9 @@ void loop() {
       if (position != last) {
         Serial.println("position count " + String(position));
         stepper.setTargetPositionInMillimeters(position);
-        while (!stepper.motionComplete());
+        while (!stepper.motionComplete()) {
+          // do nothing
+        }
         last = position;
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -549,6 +549,7 @@ void loop() {
     update_oled_values();
     while (state == IDLE) {
       if (rmv_btn_interrupt_fired) { // any push of the pause_btn acts as the "START" button in this situation
+        Serial.println("IDLE: pause/release btn");
         state = INHALE;
         pause_btn_action = PAUSE; // set for the next time the button is pushed
         btn_state_changed = true;
@@ -556,12 +557,12 @@ void loop() {
         break;
       }
       if (tvl_btn_interrupt_fired) {
+        Serial.println("IDLE: home btn");
         state = HOMING;
         tvl_btn_interrupt_fired = false;
         break;
       }
       get_encoder_values();
-      delay(100);
     }
     break;
   } // case IDLE
@@ -615,7 +616,6 @@ void loop() {
          break; // break out of the while(), but not out of the INHALE case
       }
       get_encoder_values();
-      delay(100);
     }
     if (state == INHALE) { // it didn't change to HOMING in the while()
       state = EXHALE;
@@ -661,7 +661,6 @@ void loop() {
          break; // break out of the while()
       }
       get_encoder_values();
-      delay(100);
     }
     if (state == EXHALE) { // it made it all the way through the while() with no state change
       state = INHALE;


### PR DESCRIPTION
This eliminates the sudden jarring stop caused by the emergencyStop().